### PR TITLE
Code standards updated to PHP 7.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0]
+        php: [7.1, 7.2, 7.3, 7.4, 8.0]
 
     steps:
     - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -1,31 +1,33 @@
 {
-    "name":"codeception/module-filesystem",
-    "description":"Codeception module for testing local filesystem",
-    "keywords":["codeception", "filesystem"],
-    "homepage":"http://codeception.com/",
-    "type":"library",
-    "license":"MIT",
-    "authors":[
-        {
-            "name":"Michael Bodnarchuk"
-        },
-        {
-            "name":"Gintautas Miselis"
-        }
-    ],
-    "minimum-stability": "RC",
-    "require": {
-        "php": ">=5.6.0 <9.0",
-        "codeception/codeception": "*@dev",
-        "symfony/finder": ">=2.7 <6.0"
-    },
-    "conflict": {
-        "codeception/codeception": "<4.0"
-    },
-    "autoload":{
-        "classmap": ["src/"]
-    },
-    "config": {
-        "classmap-authoritative": true
-    }
+	"name": "codeception/module-filesystem",
+	"description": "Codeception module for testing local filesystem",
+	"keywords": [ "codeception", "filesystem" ],
+	"homepage": "https://codeception.com/",
+	"type": "library",
+	"license": "MIT",
+	"authors": [
+		{
+			"name": "Michael Bodnarchuk"
+		},
+		{
+			"name": "Gintautas Miselis"
+		}
+	],
+	"minimum-stability": "RC",
+	"require": {
+		"php": "^7.1 || ^8.0",
+		"codeception/codeception": "*@dev",
+		"symfony/finder": ">=3.4 <6.0"
+	},
+	"conflict": {
+		"codeception/codeception": "<4.0"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"config": {
+		"classmap-authoritative": true
+	}
 }

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,10 @@ A Codeception module for testing local filesystem.
 [![Total Downloads](https://poser.pugx.org/codeception/module-filesystem/downloads)](https://packagist.org/packages/codeception/module-filesystem)
 [![License](https://poser.pugx.org/codeception/module-filesystem/license)](/LICENSE)
 
+## Requirements
+
+* `PHP 7.1` or higher.
+
 ## Installation
 
 ```

--- a/src/Codeception/Module/Filesystem.php
+++ b/src/Codeception/Module/Filesystem.php
@@ -1,9 +1,12 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Codeception\Module;
 
 use Codeception\Util\FileSystem as Util;
 use Symfony\Component\Finder\Finder;
-use Codeception\Module as CodeceptionModule;
+use Codeception\Module;
 use Codeception\TestInterface;
 use Codeception\Configuration;
 
@@ -19,14 +22,20 @@ use Codeception\Configuration;
  *
  * Module was developed to test Codeception itself.
  */
-class Filesystem extends CodeceptionModule
+class Filesystem extends Module
 {
-    protected $file = null;
-    protected $filepath = null;
+    protected $file;
+    /**
+     * @var string|null
+     */
+    protected $filepath;
 
+    /**
+     * @var string
+     */
     protected $path = '';
 
-    public function _before(TestInterface $test)
+    public function _before(TestInterface $test): void
     {
         $this->path = Configuration::projectDir();
     }
@@ -34,20 +43,14 @@ class Filesystem extends CodeceptionModule
     /**
      * Enters a directory In local filesystem.
      * Project root directory is used by default
-     *
-     * @param string $path
      */
-    public function amInPath($path)
+    public function amInPath(string $path): void
     {
         chdir($this->path = $this->absolutizePath($path) . DIRECTORY_SEPARATOR);
         $this->debug('Moved to ' . getcwd());
     }
 
-    /**
-     * @param string $path
-     * @return string
-     */
-    protected function absolutizePath($path)
+    protected function absolutizePath(string $path): string
     {
         // *nix way
         if (strpos($path, '/') === 0) {
@@ -70,12 +73,9 @@ class Filesystem extends CodeceptionModule
      * <?php
      * $I->openFile('composer.json');
      * $I->seeInThisFile('codeception/codeception');
-     * ?>
      * ```
-     *
-     * @param string $filename
      */
-    public function openFile($filename)
+    public function openFile(string $filename): void
     {
         $this->file = file_get_contents($this->absolutizePath($filename));
         $this->filepath = $filename;
@@ -87,12 +87,9 @@ class Filesystem extends CodeceptionModule
      * ``` php
      * <?php
      * $I->deleteFile('composer.lock');
-     * ?>
      * ```
-     *
-     * @param string $filename
      */
-    public function deleteFile($filename)
+    public function deleteFile(string $filename): void
     {
         if (!file_exists($this->absolutizePath($filename))) {
             \Codeception\PHPUnit\TestCase::fail('file not found');
@@ -106,12 +103,9 @@ class Filesystem extends CodeceptionModule
      * ``` php
      * <?php
      * $I->deleteDir('vendor');
-     * ?>
      * ```
-     *
-     * @param string $dirname
      */
-    public function deleteDir($dirname)
+    public function deleteDir(string $dirname): void
     {
         $dir = $this->absolutizePath($dirname);
         Util::deleteDir($dir);
@@ -123,13 +117,9 @@ class Filesystem extends CodeceptionModule
      * ``` php
      * <?php
      * $I->copyDir('vendor','old_vendor');
-     * ?>
      * ```
-     *
-     * @param string $src
-     * @param string $dst
      */
-    public function copyDir($src, $dst)
+    public function copyDir(string $src, string $dst): void
     {
         Util::copyDir($src, $dst);
     }
@@ -143,14 +133,11 @@ class Filesystem extends CodeceptionModule
      * <?php
      * $I->openFile('composer.json');
      * $I->seeInThisFile('codeception/codeception');
-     * ?>
      * ```
-     *
-     * @param string $text
      */
-    public function seeInThisFile($text)
+    public function seeInThisFile(string $text): void
     {
-        $this->assertStringContainsString($text, $this->file, "No text '$text' in currently opened file");
+        $this->assertStringContainsString($text, $this->file, "No text '{$text}' in currently opened file");
     }
 
     /**
@@ -162,28 +149,25 @@ class Filesystem extends CodeceptionModule
      * <?php
      * $I->openFile('composer.json');
      * $I->seeNumberNewLines(5);
-     * ?>
      * ```
      *
      * @param int $number New lines
      */
-    public function seeNumberNewLines($number)
+    public function seeNumberNewLines(int $number): void
     {
-        $lines = preg_split('/\n|\r/', $this->file);
+        $lines = preg_split('#\n|\r#', $this->file);
 
         $this->assertTrue(
-            (int) $number === count($lines),
-            "The number of new lines does not match with $number"
+            $number === count($lines),
+            "The number of new lines does not match with {$number}"
         );
     }
     /**
      * Checks that contents of currently opened file matches $regex
-     *
-     * @param string $regex
      */
-    public function seeThisFileMatches($regex)
+    public function seeThisFileMatches(string $regex): void
     {
-        $this->assertRegExp($regex, $this->file, "Contents of currently opened file does not match '$regex'");
+        $this->assertRegExp($regex, $this->file, "Contents of currently opened file does not match '{$regex}'");
     }
 
     /**
@@ -196,12 +180,9 @@ class Filesystem extends CodeceptionModule
      * <?php
      * $I->openFile('process.pid');
      * $I->seeFileContentsEqual('3192');
-     * ?>
      * ```
-     *
-     * @param string $text
      */
-    public function seeFileContentsEqual($text)
+    public function seeFileContentsEqual(string $text): void
     {
         $file = str_replace("\r", '', $this->file);
         \Codeception\PHPUnit\TestCase::assertEquals($text, $file);
@@ -214,20 +195,17 @@ class Filesystem extends CodeceptionModule
      * <?php
      * $I->openFile('composer.json');
      * $I->dontSeeInThisFile('codeception/codeception');
-     * ?>
      * ```
-     *
-     * @param string $text
      */
-    public function dontSeeInThisFile($text)
+    public function dontSeeInThisFile(string $text): void
     {
-        $this->assertStringNotContainsString($text, $this->file, "Found text '$text' in currently opened file");
+        $this->assertStringNotContainsString($text, $this->file, "Found text '{$text}' in currently opened file");
     }
 
     /**
      * Deletes a file
      */
-    public function deleteThisFile()
+    public function deleteThisFile(): void
     {
         $this->deleteFile($this->filepath);
     }
@@ -239,13 +217,9 @@ class Filesystem extends CodeceptionModule
      * ``` php
      * <?php
      * $I->seeFileFound('UserModel.php','app/models');
-     * ?>
      * ```
-     *
-     * @param string $filename
-     * @param string $path
      */
-    public function seeFileFound($filename, $path = '')
+    public function seeFileFound(string $filename, string $path = ''): void
     {
         if ($path === '' && file_exists($filename)) {
             $this->openFile($filename);
@@ -256,7 +230,7 @@ class Filesystem extends CodeceptionModule
         $found = $this->findFileInPath($filename, $path);
 
         if ($found === false) {
-            $this->fail("File \"$filename\" not found at \"$path\"");
+            $this->fail(sprintf('File "%s" not found at "%s"', $filename, $path));
         }
 
         $this->openFile($found);
@@ -265,11 +239,8 @@ class Filesystem extends CodeceptionModule
 
     /**
      * Checks if file does not exist in path
-     *
-     * @param string $filename
-     * @param string $path
      */
-    public function dontSeeFileFound($filename, $path = '')
+    public function dontSeeFileFound(string $filename, string $path = ''): void
     {
         if ($path === '') {
             \Codeception\PHPUnit\TestCase::assertFileNotExists($filename);
@@ -290,16 +261,14 @@ class Filesystem extends CodeceptionModule
     /**
      * Finds the first matching file
      *
-     * @param string $filename
-     * @param string $path
      * @throws \PHPUnit\Framework\AssertionFailedError When path does not exist
      * @return string|false Path to the first matching file
      */
-    private function findFileInPath($filename, $path)
+    private function findFileInPath(string $filename, string $path)
     {
         $path = $this->absolutizePath($path);
         if (!file_exists($path)) {
-            $this->fail("Directory does not exist: $path");
+            $this->fail(sprintf('Directory does not exist: %s', $path));
         }
 
         $files = Finder::create()->files()->name($filename)->in($path);
@@ -319,12 +288,9 @@ class Filesystem extends CodeceptionModule
      * ``` php
      * <?php
      * $I->cleanDir('logs');
-     * ?>
      * ```
-     *
-     * @param string $dirname
      */
-    public function cleanDir($dirname)
+    public function cleanDir(string $dirname): void
     {
         $path = $this->absolutizePath($dirname);
         Util::doEmptyDir($path);
@@ -332,11 +298,8 @@ class Filesystem extends CodeceptionModule
 
     /**
      * Saves contents to file
-     *
-     * @param string $filename
-     * @param string $contents
      */
-    public function writeToFile($filename, $contents)
+    public function writeToFile(string $filename, string $contents): void
     {
         file_put_contents($filename, $contents);
     }

--- a/tests/unit/Codeception/Module/FilesystemTest.php
+++ b/tests/unit/Codeception/Module/FilesystemTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Codeception\Module\Filesystem;
 use Codeception\Stub;
 use PHPUnit\Framework\AssertionFailedError;
@@ -7,11 +9,11 @@ use PHPUnit\Framework\AssertionFailedError;
 if (!function_exists('make_container')) {
     function make_container()
     {
-        return Stub::make('Codeception\Lib\ModuleContainer');
+        return Stub::make(\Codeception\Lib\ModuleContainer::class);
     }
 }
 
-class FilesystemTest extends \Codeception\PHPUnit\TestCase
+final class FilesystemTest extends \Codeception\PHPUnit\TestCase
 {
 
     /**
@@ -22,13 +24,13 @@ class FilesystemTest extends \Codeception\PHPUnit\TestCase
     public function _setUp()
     {
         $this->module = new Filesystem(make_container());
-        $this->module->_before(Stub::makeEmpty('\Codeception\Test\Test'));
+        $this->module->_before(Stub::makeEmpty(\Codeception\Test\Test::class));
     }
 
 
     public function _tearDown()
     {
-        $this->module->_after(Stub::makeEmpty('\Codeception\Test\Test'));
+        $this->module->_after(Stub::makeEmpty(\Codeception\Test\Test::class));
     }
 
     public function testSeeFileFoundPassesWhenFileExists()


### PR DESCRIPTION
- The minimum version of PHP is now 7.1
- Added strict types
- Added return types
- Added typehints
- Fix naming
- Removed unnecessary qualifiers