### PR TITLE
Update Codeception restriction to ^5.0.0-alpha2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"homepage": "https://codeception.com/",
 	"require": {
 		"php": "^8.0",
-		"codeception/codeception": "dev-5.0-interfaces as 5.0.0",
+		"codeception/codeception": "^5.0.0-alpha2",
 		"symfony/finder": "^4.4 || ^5.4 || ^6.0"
 	},
 	"conflict": {


### PR DESCRIPTION
Updated codeception version to alpha2 as required by this pull request https://github.com/Codeception/module-yii2/pull/63