### PR TITLE
openFile: Fail correctly if the file doesn't exist

### DIFF
--- a/src/Codeception/Module/Filesystem.php
+++ b/src/Codeception/Module/Filesystem.php
@@ -79,10 +79,11 @@ class Filesystem extends Module
      */
     public function openFile(string $filename): void
     {
-        if (!file_exists($this->absolutizePath($filename))) {
+        $absolutePath = $this->absolutizePath($filename);
+        if (!file_exists($absolutePath)) {
             TestCase::fail('file not found');
         }
-        $this->file = file_get_contents($this->absolutizePath($filename));
+        $this->file = file_get_contents($absolutePath);
         $this->filePath = $filename;
     }
 
@@ -96,11 +97,12 @@ class Filesystem extends Module
      */
     public function deleteFile(string $filename): void
     {
-        if (!file_exists($this->absolutizePath($filename))) {
+        $absolutePath = $this->absolutizePath($filename);
+        if (!file_exists($absolutePath)) {
             TestCase::fail('file not found');
         }
 
-        unlink($this->absolutizePath($filename));
+        unlink($absolutePath);
     }
 
     /**

--- a/src/Codeception/Module/Filesystem.php
+++ b/src/Codeception/Module/Filesystem.php
@@ -43,7 +43,11 @@ class Filesystem extends Module
      */
     public function amInPath(string $path): void
     {
-        chdir($this->path = $this->absolutizePath($path) . DIRECTORY_SEPARATOR);
+        $this->path = $this->absolutizePath($path) . DIRECTORY_SEPARATOR;
+        if (!file_exists($this->path)) {
+            TestCase::fail('directory not found');
+        }
+        chdir($this->path);
         $this->debug('Moved to ' . getcwd());
     }
 
@@ -75,6 +79,9 @@ class Filesystem extends Module
      */
     public function openFile(string $filename): void
     {
+        if (!file_exists($this->absolutizePath($filename))) {
+            TestCase::fail('file not found');
+        }
         $this->file = file_get_contents($this->absolutizePath($filename));
         $this->filePath = $filename;
     }


### PR DESCRIPTION
I fixed 2 issues:

```
 I see file found "_log/.gitkeep"
<warning>PHP Warning:  file_get_contents(/.../Codeception/tests/data/included/tests/data/included/_log/.gitkeep): Failed to open stream: No such file or directory in /.../Codeception/vendor/codeception/module-filesystem/src/Codeception/Module/Filesystem.php on line 78</warning>
TypeError: Cannot assign bool to property Codeception\Module\Filesystem::$file of type string
```


```
 I am in path "tests/data/included"
<warning>PHP Warning:  chdir(): No such file or directory (errno 2) in /.../Codeception/vendor/codeception/module-filesystem/src/Codeception/Module/Filesystem.php on line 46</warning>
  Moved to /.../Codeception/tests/data/included
```