### PR TITLE
[TASK] Allow codeception/codeception 5.0.0 release along with dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	"homepage": "https://codeception.com/",
 	"require": {
 		"php": "^8.0",
-		"codeception/codeception": "*@dev",
+		"codeception/codeception": "^5.0 || *@dev",
 		"symfony/finder": "^4.4 || ^5.4 || ^6.0"
 	},
 	"conflict": {


### PR DESCRIPTION
codeception/codeception has been relased. Add released version for
require package, so installation with released version is possible.

Used command:

```
composer req --no-update codeception/codeception:"^5.0 || *@dev"
```

Would be nice to have a release afterwards to use it along with codeception.